### PR TITLE
Created "isAllowOnlyOneDrag" attribute

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -683,6 +683,7 @@ export namespace Components {
           * Unique identifier for the text element.
          */
         "id": string;
+        "isAllowOnlyOneDrop": string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
          */
@@ -1701,6 +1702,7 @@ declare namespace LocalJSX {
           * Unique identifier for the text element.
          */
         "id"?: string;
+        "isAllowOnlyOneDrop"?: string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
          */

--- a/src/components/root/assets/xmlData.xml
+++ b/src/components/root/assets/xmlData.xml
@@ -83,12 +83,12 @@
 					</lido-col>
 
 					<lido-row id="lido-dropId" visible="true" bgColor="transparent" width="700px" height="150px" x="490px" y="620px">
-						<lido-text visible="true"  tabIndex="1" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="I" type="drop"  onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect=""></lido-text>
-						<lido-text visible="true" tabIndex="2" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="can" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect=""></lido-text>
-						<lido-text visible="true" tabIndex="3" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="see" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect=""></lido-text>
-						<lido-text visible="true" tabIndex="4" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="with" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect=""></lido-text>
-						<lido-text visible="true" tabIndex="5" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="my" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect=""></lido-text>
-						<lido-text visible="true" tabIndex="6" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="eyes" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect=""></lido-text>
+						<lido-text visible="true"  tabIndex="1" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="I" type="drop"  onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect="" isAllowOnlyOneDrop="true"></lido-text>
+						<lido-text visible="true" tabIndex="2" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="can" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect="" isAllowOnlyOneDrop="true"></lido-text>
+						<lido-text visible="true" tabIndex="3" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="see" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect="" isAllowOnlyOneDrop="true"></lido-text>
+						<lido-text visible="true" tabIndex="4" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="with" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect="" isAllowOnlyOneDrop="true"></lido-text>
+						<lido-text visible="true" tabIndex="5" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="my" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect="" isAllowOnlyOneDrop="true"></lido-text>
+						<lido-text visible="true" tabIndex="6" width="100px" height="80px" onEntry="this.border='dashed 2px';" bgColor="transparent" value="eyes" type="drop" onCorrect="this.boxShadow='unset'; element.animation='unset';" onInCorrect="" isAllowOnlyOneDrop="true"></lido-text>
 					</lido-row>
 				</lido-pos>
 
@@ -104,7 +104,7 @@
 				</lido-pos>
 					
 				<lido-pos visible="true" id="lido-check-pos" width="200px" height="60px" x="1300px" y="100px" bgColor="transparent">
-					<lido-text visible="true" id="lido-checkButton" width="200px" height="60px" bgColor="blue" font="Poppins" font-size="30px" fontColor="white" string="Check" type="click" onEntry="" onTouch="this.next='true';"></lido-text>
+					<lido-text visible="true" id="lido-checkButton" width="200px" height="60px" bgColor="blue" font="Poppins" font-size="30px" fontColor="white" string="Check" type="click" onEntry="this.addClass='lido-disable-check-button';" onTouch="this.next='true';"></lido-text>
 				</lido-pos>
 			
 	</lido-container>
@@ -120,7 +120,7 @@
 					<lido-text visible="true" width="600px" height="100px" onEntry="this.boxShadow='unset';" string='Which animal is known as the "king of the jungle"?' font="Poppins" font-size="25px" value="lion" bgColor="rgba(210, 140, 80, 1)"></lido-text>
 
 					<lido-row visible="true" width="800px" height="100px" bgColor="transparent" >
-						<lido-col visible="true" width="150px" height="120px"  type="click" onEntry="" value="giraffe" onCorrect="this.border='2px solid red';">
+						<lido-col visible="true" width="150px" height="120px"  type="click" onEntry="" value="giraffe" onInCorrect="this.border='2px solid red';">
 							<lido-image visible="true" width="150px" height="100px" src="./build/assets/images/animals/giraffe.png" ></lido-image>
 							<lido-text visible="true" width="150px" font="Poppins" font-size="20px" string="GIRAFFE" bgColor="transparent" onEntry="this.boxShadow='unset';"></lido-text>
 						</lido-col>

--- a/src/components/text/lido-text.tsx
+++ b/src/components/text/lido-text.tsx
@@ -129,6 +129,8 @@ export class LidoText {
    */
   @Prop() onEntry: string;
 
+  @Prop() isAllowOnlyOneDrop: string;
+
   /**
    * Reference to the HTML element representing this `lido-text` component.
    */
@@ -172,6 +174,7 @@ export class LidoText {
         style={style}
         aria-label={this.ariaLabel}
         aria-hidden={this.ariaHidden}
+        isAllowOnlyOneDrop={this.isAllowOnlyOneDrop}
       >
         {this.string}
       </Host>

--- a/src/components/text/lido-text.tsx
+++ b/src/components/text/lido-text.tsx
@@ -129,6 +129,11 @@ export class LidoText {
    */
   @Prop() onEntry: string;
 
+  /**
+   * Determines whether only a single draggable element is allowed to be dropped.
+   * If set to 'true', only one draggable element can be dropped in the drop zone.
+   * If set to 'false', multiple draggable elements are allowed.
+   */
   @Prop() isAllowOnlyOneDrop: string;
 
   /**

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,11 @@
-
-
 @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-
 
 body {
   overflow: hidden;
 }
 
 .lido-disable-check-button {
-  pointer-events: none; 
-  background-color: #9393935c !important; 
+  pointer-events: none;
+  background-color: #9393935c !important;
   color: white;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -288,16 +288,16 @@ function enableDraggingWithScaling(element: HTMLElement): void {
       initialY = 0;
     }
 
-    const rect1 = container.getBoundingClientRect();
-    const rect2 = element.getBoundingClientRect();
-    verticalDistance = rect1.top - rect2.top;
-    horizontalDistance = rect1.left - rect2.left;
-
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onEnd);
     document.addEventListener('touchmove', onMove);
     document.addEventListener('touchend', onEnd);
   };
+
+  const rect1 = container.getBoundingClientRect();
+  const rect2 = element.getBoundingClientRect();
+  verticalDistance = rect1.top - rect2.top;
+  horizontalDistance = rect1.left - rect2.left;
 
   const observer = new MutationObserver(mutationsList => {
     for (const mutation of mutationsList) {
@@ -533,16 +533,13 @@ const executeActions = async (actionsString: string, thisElement: HTMLElement, e
 
           const container = document.getElementById('lido-container');
           const containerScale = getElementScale(container);
-          const containerRect = container.getBoundingClientRect();
+          dragElement.style.transform = 'translate(0,0)';
           const dropRect = dropElement.getBoundingClientRect();
+          const dragRect = dragElement.getBoundingClientRect();
 
-          const scaledLeft = (dropRect.left - containerRect.left) / containerScale;
-          const scaledTop = (dropRect.top - containerRect.top) / containerScale;
-
-          dragElement.style.position = 'fixed';
-          dragElement.style.left = `${scaledLeft}px`;
-          dragElement.style.top = `${scaledTop}px`;
-          dragElement.style.transform = `translate(0px, 0px)`;
+          const scaledLeft = (dropRect.left - dragRect.left) / containerScale;
+          const scaledTop = (dropRect.top - dragRect.top) / containerScale;
+          dragElement.style.transform = `translate(${scaledLeft}px, ${scaledTop}px)`;
           break;
         }
         case 'addClass': {


### PR DESCRIPTION
- Created the "isAllowOnlyOneDrag" attribute for each drop element.

- Updated the XML file.

- Fixed the issue with storing the value.

- Fixed dragging issue as well.

- Create a common function named "findOverlappedElement()" to retrieve the overlapped element. This function can be called whenever an overlapped element is needed.