### PR TITLE
 removing box-shadow  when the element is in dropZone

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -55,6 +55,10 @@ body {
   box-shadow: 0px 15px 11px rgba(43, 0, 0, 0.3) !important ;
 }
 
+.drag-element.dropped {
+  box-shadow: none !important ;
+}
+
 .click-element {
   background-color: var(--btn-bg-color, rgba(255, 172, 76, 1)) !important;
   box-shadow: var(--btn-shadow-px) var(--btn-shadow-color, rgba(225, 121, 76, 1)) !important;

--- a/src/utils/utilsHandlers/dragDropHandler.ts
+++ b/src/utils/utilsHandlers/dragDropHandler.ts
@@ -446,7 +446,7 @@ export async function onElementDropComplete(dragElement: HTMLElement, dropElemen
     dragElement.setAttribute(DropTimeAttr, new Date().getTime().toString());
   }
   if (dropElement) {
-    
+    dragElement.classList.add('dropped');
     if (!(dropElement.getAttribute('dropAttr')?.toLowerCase() === DropMode.Diagonal) && (dropElement.getAttribute('minDrops') === '1' || !dropElement.getAttribute('minDrops'))) {
       const isisFull = Object.values(dropHasDrag).find(item => document.getElementById(item.drop) === dropElement);
       if (isisFull) {
@@ -503,6 +503,7 @@ export async function onElementDropComplete(dragElement: HTMLElement, dropElemen
     }
   }
   if (!dropElement) {
+    dragElement.classList.remove('dropped');
     const container = document.getElementById(LidoContainer) as HTMLElement;
     const cloneArray = container.querySelectorAll(`#${dragElement.id}`);
     const cloneDragElement = Array.from(cloneArray).find(item => dragElement !== item) as HTMLElement;

--- a/src/utils/utilsHandlers/sortHandler.ts
+++ b/src/utils/utilsHandlers/sortHandler.ts
@@ -207,6 +207,7 @@ export function enableReorderDrag(element: HTMLElement): void {
           });
 
           optionArea.appendChild(element);
+          element.classList.remove('dropped');
           if (dummy) {
             dummy.remove();
           }
@@ -263,7 +264,8 @@ export function enableReorderDrag(element: HTMLElement): void {
         setTimeout(() => {
           resetElementStyles(element);
           dummy.replaceWith(element);
-        }, 500);
+           element.classList.remove('dropped');
+        }, 100);
         return;
       } else {
         if (!category) return;
@@ -277,7 +279,7 @@ export function enableReorderDrag(element: HTMLElement): void {
           onDropToCategory(element, category);
           element.style.transform = 'translate(0,0)';
           element.style.marginBottom = '10px';
-        }, 500);
+        }, 100);
         return;
       }
     }
@@ -435,6 +437,7 @@ const wordDropComplete = (block: HTMLElement, element?: HTMLElement) => {
 };
 
 async function onDropToCategory(dragElement: HTMLElement, categoryElement: HTMLElement) {
+  dragElement.classList.add('dropped');
   let dragSelected = JSON.parse(localStorage.getItem(DragSelectedMapKey)) || {};
   let elementArr = dragSelected[categoryElement.getAttribute('tab-index')];
 


### PR DESCRIPTION
When the element is in dropZone the box-shadow of the drag Element is removed and when it comes back to its original position it takes the box-shadow
![Uploading box-shadow.png…]()


