### PR TITLE
Remove duplicate lido-cell and and execute onCorrect action conditionally with append logic

### DIFF
--- a/src/components/image/readme.md
+++ b/src/components/image/readme.md
@@ -12,9 +12,7 @@
 | `audio`         | `audio`           | URL or identifier of an audio file associated with the image.                                                                                | `string`            | `undefined` |
 | `bgColor`       | `bg-color`        | Background color for the container of the image (CSS color value, e.g., '#FFFFFF', 'blue').                                                  | `string`            | `undefined` |
 | `borderRadius`  | `border-radius`   | CSS filter to apply border radius to the image. Example: '10px' for  images.                                                                 | `string`            | `'0px'`     |
-
 | `delayVisible`  | `delay-visible`   | Delay in milliseconds to make the cell visible after mount.                                                                                  | `string`            | `''`        |
-
 | `filter`        | `filter`          | CSS filter to apply visual effects (e.g., blur, brightness) to the image. Example: 'blur(5px)', 'brightness(0.8)', 'grayscale(100%)'         | `string`            | `''`        |
 | `height`        | `height`          | The height of the image component (CSS value, e.g., '100px', '50%').                                                                         | `string`            | `undefined` |
 | `id`            | `id`              | Unique identifier for the text element.                                                                                                      | `string`            | `undefined` |

--- a/src/stories/Templates/create-sentence/createSentence.stories.ts
+++ b/src/stories/Templates/create-sentence/createSentence.stories.ts
@@ -73,11 +73,8 @@ function getContainerXml(args) {
 					</lido-text>
 				</lido-cell>
 
-				<lido-cell layout="row" visible="true" delay-visible="2650" width="landscape.70%, portrait.88%" y="landscape.40%, portrait.42%" x="0%" z="2" onEntry="this.position='relative'">
-					<lido-text id="option1" value="${args.option1}" tab-index="5" flexible-width="false" visible="true" bg-color="#FCF3B1" onEntry="this.borderRadius='25px'; this.boxShadow='unset'; this.fontWeight='800'; " width="150px" height="90px" string="${args.option1}" font-family="'Baloo 2', serif" font-size="24px" z="2" type="drag">
-
-				</lido-cell>
-				<lido-cell layout="wrap" visible="true" width="landscape.38%, portrait.88%" y="landscape.58%, portrait.62%" x="landscape.4%,portrait.0px" z="2" onEntry="this.gridTemplateColumns = 'repeat(4, 1fr)';  this.gridTemplateRows = 'repeat(2, 1fr)';this.position='relative';this.gap='40px';">
+				
+				<lido-cell layout="wrap" visible="true" delay-visible="2650" width="landscape.38%, portrait.88%" y="landscape.53%, portrait.62%" x="landscape.35%,portrait.5%" z="2" onEntry="this.gridTemplateColumns = 'repeat(4, 1fr)';  this.gridTemplateRows = 'repeat(2, 1fr)';this.position='relative';this.gap='40px';">
 					<lido-text id="option1" show-speak-icon="true" value="${args.option1}" tab-index="9"  visible="true" bg-color="#FCF3B1" onEntry="this.padding='0px 40px';this.borderRadius='25px'; this.boxShadow='unset'; this.fontWeight='800';  " width="auto" height="84px" string="${args.option1}" font-family="'Baloo 2', serif" font-size="24px" z="2" type="drag">
 					</lido-text>
 					<lido-text id="option2" show-speak-icon="true" value="${args.option2}" tab-index="10"  visible="true" bg-color="#FCF3B1" onEntry="this.padding='0px 40px';this.borderRadius='25px'; this.boxShadow='unset'; this.fontWeight='800'; " width="auto" height="84px" string="${args.option2}" font-family="'Baloo 2', serif" font-size="24px" z="2" type="drag">

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -489,12 +489,12 @@ export const validateObjectiveStatus = async () => {
     }
     if (res) {
       const attach = container.getAttribute('appendToDropOnCompletion');
-      if (attach === 'true') {
-        appendingDragElementsInDrop();
-      }
       const onCorrect = container.getAttribute('onCorrect');
       if (onCorrect) {
         await executeActions(onCorrect, container);
+        if (attach === 'true') {
+          appendingDragElementsInDrop();
+        }
       }
       triggerNextContainer();
     } else {


### PR DESCRIPTION
1. Removed one of the two <lido-cell> elements that had similar layout and attributes, to eliminate redundancy and keep the DOM clean.

2. Improved conditional execution of appendingDragElementsInDrop(): now it runs only if appendToDropOnCompletion="true", even after the onCorrect action is executed.