### PR TITLE
Created Lido-math-matrix component

### DIFF
--- a/src/assets/index.xml
+++ b/src/assets/index.xml
@@ -1,8 +1,9 @@
 <main>
 	
 	<lido-container visible="true" show-next-button="true">
-		<lido-math-matrix visible="true" rows="10" cols="10" top-index="false" left-index="false" bottom-index="false" clickable="true" active-only-visible="false" active-bg-color="yellow" deactive-bg-color="black" matrix-image="https://aeakbcdznktpsbrfsgys.supabase.co/storage/v1/object/public/template-assets/Categorize/insect3.png"></lido-math-matrix>
+		<lido-math-matrix visible="true" rows="10" cols="10" top-index="true" left-index="true" bottom-index="true" clickable="true" active-only-visible="false" active-bg-color="yellow" inactive-bg-color="black" defualt-fill="7" matrix-image="https://aeakbcdznktpsbrfsgys.supabase.co/storage/v1/object/public/template-assets/Categorize/insect3.png"></lido-math-matrix>
 	</lido-container>
+
 	<lido-container id="lido-container" show-next-button="true" show-drop-border="false" tabIndex="1"  value="mainContainer1"   bg-Color="#FFF"  height="100%" width="100%" visible="true" objective="(झींगुर|मक्खी),(मकड़ी|मकड़ी-2),(कनखजूरा|कनखजूरा2)" show-Check="false" is-Continue-On-Correct="true" after-Drop="false" onCorrect="lido-avatar.avatarAnimate='Success'; this.sleep='2000';"   onInCorrect="lido-avatar.avatarAnimate='Fail'; this.sleep='2000';" is-allow-only-correct="false"   > 
 		
 		<!-- parent cell -->

--- a/src/assets/index.xml
+++ b/src/assets/index.xml
@@ -1,6 +1,8 @@
 <main>
 	
-
+	<lido-container visible="true" show-next-button="true">
+		<lido-math-matrix visible="true" rows="10" cols="10" top-index="false" left-index="false" bottom-index="false" clickable="true" active-only-visible="false" active-bg-color="yellow" deactive-bg-color="black" matrix-image="https://aeakbcdznktpsbrfsgys.supabase.co/storage/v1/object/public/template-assets/Categorize/insect3.png"></lido-math-matrix>
+	</lido-container>
 	<lido-container id="lido-container" show-next-button="true" show-drop-border="false" tabIndex="1"  value="mainContainer1"   bg-Color="#FFF"  height="100%" width="100%" visible="true" objective="(झींगुर|मक्खी),(मकड़ी|मकड़ी-2),(कनखजूरा|कनखजूरा2)" show-Check="false" is-Continue-On-Correct="true" after-Drop="false" onCorrect="lido-avatar.avatarAnimate='Success'; this.sleep='2000';"   onInCorrect="lido-avatar.avatarAnimate='Fail'; this.sleep='2000';" is-allow-only-correct="false"   > 
 		
 		<!-- parent cell -->

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -951,10 +951,6 @@ export namespace Components {
          */
         "cols": number;
         /**
-          * Background color for inactive slots
-         */
-        "deactiveBgColor": string;
-        /**
           * Number of slots to pre-fill as active by default
          */
         "defualtFill": number;
@@ -962,6 +958,10 @@ export namespace Components {
           * Height of the slot container
          */
         "height": string;
+        /**
+          * Background color for inactive slots
+         */
+        "inactiveBgColor": string;
         /**
           * Show row index numbers on the left side
          */
@@ -3024,10 +3024,6 @@ declare namespace LocalJSX {
          */
         "cols"?: number;
         /**
-          * Background color for inactive slots
-         */
-        "deactiveBgColor"?: string;
-        /**
           * Number of slots to pre-fill as active by default
          */
         "defualtFill"?: number;
@@ -3035,6 +3031,10 @@ declare namespace LocalJSX {
           * Height of the slot container
          */
         "height"?: string;
+        /**
+          * Background color for inactive slots
+         */
+        "inactiveBgColor"?: string;
         /**
           * Show row index numbers on the left side
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -921,6 +921,84 @@ export namespace Components {
          */
         "z"?: string;
     }
+    interface LidoMathMatrix {
+        /**
+          * Background color for active slots
+         */
+        "activeBgColor": string;
+        /**
+          * If true, only active slots are visible; inactive ones are hidden
+         */
+        "activeOnlyVisible": boolean;
+        /**
+          * Border style applied to each slot
+         */
+        "border": string;
+        /**
+          * Border radius for each slot
+         */
+        "borderRadius": string;
+        /**
+          * Show row index numbers on the bottom side
+         */
+        "bottomIndex": boolean;
+        /**
+          * Enable/disable click interactions on the slots
+         */
+        "clickable": boolean;
+        /**
+          * Number of columns in the matrix
+         */
+        "cols": number;
+        /**
+          * Background color for inactive slots
+         */
+        "deactiveBgColor": string;
+        /**
+          * Number of slots to pre-fill as active by default
+         */
+        "defualtFill": number;
+        /**
+          * Height of the slot container
+         */
+        "height": string;
+        /**
+          * Show row index numbers on the left side
+         */
+        "leftIndex": boolean;
+        /**
+          * Margin around the matrix container
+         */
+        "margin": string;
+        /**
+          * Image source used inside the slots
+         */
+        "matrixImage": string;
+        /**
+          * Padding inside the matrix container
+         */
+        "padding": string;
+        /**
+          * Number of rows in the matrix
+         */
+        "rows": number;
+        /**
+          * Show column index numbers on the top side
+         */
+        "topIndex": boolean;
+        /**
+          * Controls visibility of the matrix (string "true" or "false")
+         */
+        "visible": string;
+        /**
+          * Width of the slot container
+         */
+        "width": string;
+        /**
+          * Z-index value for the matrix container
+         */
+        "z": string;
+    }
     /**
      * @component LidoPos
      * The `LidoPos` component is used to position a block-level element with dynamic styling and event handling.
@@ -1877,6 +1955,12 @@ declare global {
         prototype: HTMLLidoKeyboardElement;
         new (): HTMLLidoKeyboardElement;
     };
+    interface HTMLLidoMathMatrixElement extends Components.LidoMathMatrix, HTMLStencilElement {
+    }
+    var HTMLLidoMathMatrixElement: {
+        prototype: HTMLLidoMathMatrixElement;
+        new (): HTMLLidoMathMatrixElement;
+    };
     /**
      * @component LidoPos
      * The `LidoPos` component is used to position a block-level element with dynamic styling and event handling.
@@ -1982,6 +2066,7 @@ declare global {
         "lido-home": HTMLLidoHomeElement;
         "lido-image": HTMLLidoImageElement;
         "lido-keyboard": HTMLLidoKeyboardElement;
+        "lido-math-matrix": HTMLLidoMathMatrixElement;
         "lido-pos": HTMLLidoPosElement;
         "lido-random": HTMLLidoRandomElement;
         "lido-root": HTMLLidoRootElement;
@@ -2909,6 +2994,84 @@ declare namespace LocalJSX {
          */
         "z"?: string;
     }
+    interface LidoMathMatrix {
+        /**
+          * Background color for active slots
+         */
+        "activeBgColor"?: string;
+        /**
+          * If true, only active slots are visible; inactive ones are hidden
+         */
+        "activeOnlyVisible"?: boolean;
+        /**
+          * Border style applied to each slot
+         */
+        "border"?: string;
+        /**
+          * Border radius for each slot
+         */
+        "borderRadius"?: string;
+        /**
+          * Show row index numbers on the bottom side
+         */
+        "bottomIndex"?: boolean;
+        /**
+          * Enable/disable click interactions on the slots
+         */
+        "clickable"?: boolean;
+        /**
+          * Number of columns in the matrix
+         */
+        "cols"?: number;
+        /**
+          * Background color for inactive slots
+         */
+        "deactiveBgColor"?: string;
+        /**
+          * Number of slots to pre-fill as active by default
+         */
+        "defualtFill"?: number;
+        /**
+          * Height of the slot container
+         */
+        "height"?: string;
+        /**
+          * Show row index numbers on the left side
+         */
+        "leftIndex"?: boolean;
+        /**
+          * Margin around the matrix container
+         */
+        "margin"?: string;
+        /**
+          * Image source used inside the slots
+         */
+        "matrixImage"?: string;
+        /**
+          * Padding inside the matrix container
+         */
+        "padding"?: string;
+        /**
+          * Number of rows in the matrix
+         */
+        "rows"?: number;
+        /**
+          * Show column index numbers on the top side
+         */
+        "topIndex"?: boolean;
+        /**
+          * Controls visibility of the matrix (string "true" or "false")
+         */
+        "visible"?: string;
+        /**
+          * Width of the slot container
+         */
+        "width"?: string;
+        /**
+          * Z-index value for the matrix container
+         */
+        "z"?: string;
+    }
     /**
      * @component LidoPos
      * The `LidoPos` component is used to position a block-level element with dynamic styling and event handling.
@@ -3778,6 +3941,7 @@ declare namespace LocalJSX {
         "lido-home": LidoHome;
         "lido-image": LidoImage;
         "lido-keyboard": LidoKeyboard;
+        "lido-math-matrix": LidoMathMatrix;
         "lido-pos": LidoPos;
         "lido-random": LidoRandom;
         "lido-root": LidoRoot;
@@ -3843,6 +4007,7 @@ declare module "@stencil/core" {
              */
             "lido-image": LocalJSX.LidoImage & JSXBase.HTMLAttributes<HTMLLidoImageElement>;
             "lido-keyboard": LocalJSX.LidoKeyboard & JSXBase.HTMLAttributes<HTMLLidoKeyboardElement>;
+            "lido-math-matrix": LocalJSX.LidoMathMatrix & JSXBase.HTMLAttributes<HTMLLidoMathMatrixElement>;
             /**
              * @component LidoPos
              * The `LidoPos` component is used to position a block-level element with dynamic styling and event handling.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -17,102 +17,82 @@ export namespace Components {
     interface LidoAvatar {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * Audio file URL or identifier for sound that will be associated with the column.
-          * @default ''
          */
         "audio": string;
         /**
           * The background color of the column (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * The height of the column component (CSS value, e.g., '100px', '50%').
-          * @default ''
          */
         "height": string;
         /**
           * The unique identifier for the column component.
-          * @default ''
          */
         "id": string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler for when the column is entered, which can be used to initiate specific behaviors on entry.
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler for a touch event, where a custom function can be triggered when the column is touched.
-          * @default ''
          */
         "onTouch": string;
         /**
           * Source URL of the Rive (.riv) file
-          * @default ''
          */
         "src": string;
         /**
           * The tab index value, used to set the tab order of the column for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * Defines the type of the column, which can be used for styling or specific logic handling.
-          * @default ''
          */
         "type": string;
         /**
           * The value associated with the column component. Typically used for internal logic.
-          * @default ''
          */
         "value": string;
         /**
           * A boolean that controls whether the column is visible (`true`) or hidden (`false`).
-          * @default false
          */
         "visible": boolean;
         /**
           * The width of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width": string;
         /**
           * The x-coordinate (left position) of the column within its container (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x": string;
         /**
           * The y-coordinate (top position) of the column within its container (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y": string;
         /**
           * The z-index of the column to control stacking order.
-          * @default '0'
          */
         "z": string;
     }
@@ -125,167 +105,134 @@ export namespace Components {
     interface LidoCell {
         /**
           * CSS align-items property to control the alignment of flex items. Example: 'flex-start', 'flex-end', 'center', 'baseline', 'stretch'.
-          * @default ''
          */
         "alignItems": string;
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * Audio file URL or identifier for sound that will be associated with the column.
-          * @default ''
          */
         "audio": string;
         /**
           * The background color of the column (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor": string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius": string;
         /**
           * The number of child elements that should be displayed inside the row. This value is dynamically adjusted based on `minLength` and `maxLength`.
-          * @default 9999
          */
         "childElementsLength": number;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * CSS flex direction for the component, which can be used to control the layout of child elements. Accepts values like 'row', 'column', etc.
-          * @default ''
          */
         "flexDirection": string;
         /**
           * The gap between child elements inside the column (CSS value, e.g., '10px', '5px 10px'). This is applicable when the layout is set to `wrap` or `flex`.
-          * @default '0'
          */
         "gap": string;
         /**
           * The height of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height": string;
         /**
           * The unique identifier for the column component.
-          * @default ''
          */
         "id": string;
         /**
           * Determines the layout behavior of the component's children.  - `wrap`: Applies a grid layout to the children, allowing them to wrap automatically in a grid format. - `flex`: Applies a flex layout with wrapping behavior (`flex-wrap`). - `col`: Arranges children in a single column using a vertical flex direction. - `row`: Arranges children in a single row using a horizontal flex direction. - `pos`: Applies absolute positioning to children, allowing manual placement using `x` and `y` values. - `random`: Positions child elements randomly within the container using absolute positioning.  Default: `'wrap'`
-          * @default 'wrap'
          */
         "layout": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
           * The maximum number of child elements that can be displayed inside the row. If `childElementsLength` exceeds this value, excess elements will be hidden.
-          * @default 9999
          */
         "maxLength": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
           * The minimum number of child elements that must be displayed inside the row. If `childElementsLength` is less than this value, additional elements may be shown to meet this minimum.
-          * @default 0
          */
         "minLength": number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler for when the column is entered, which can be used to initiate specific behaviors on entry.
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler for a touch event, where a custom function can be triggered when the column is touched.
-          * @default ''
          */
         "onTouch": string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding": string;
         /**
           * Defines the width of the scrollbar within the cell (e.g., '14px'). Defaults to '0px' if not specified, effectively hiding the scrollbar.
-          * @default ''
          */
         "scrollbarWidth": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
           * The tab index value, used to set the tab order of the column for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * Defines the type of the column, which can be used for styling or specific logic handling.
-          * @default ''
          */
         "type": string;
         /**
           * The value associated with the column component. Typically used for internal logic.
-          * @default ''
          */
         "value": string;
         /**
           * A boolean that controls whether the column is visible (`true`) or hidden (`false`).
-          * @default 'false'
          */
         "visible": string;
         /**
           * The width of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width": string;
         /**
           * The x-coordinate (left position) of the column within its container (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x": string;
         /**
           * The y-coordinate (top position) of the column within its container (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y": string;
         /**
           * The z-index of the column to control stacking order.
-          * @default '0'
          */
         "z": string;
     }
@@ -340,12 +287,10 @@ export namespace Components {
         "id": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
@@ -354,7 +299,6 @@ export namespace Components {
         "maxLength": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
@@ -379,7 +323,6 @@ export namespace Components {
         "onTouch": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
@@ -424,52 +367,42 @@ export namespace Components {
     interface LidoContainer {
         /**
           * Enables appending the dragged element to the drop target after all correct drops are completed.
-          * @default false
          */
         "appendToDropOnCompletion": boolean;
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default 'auto'
          */
         "ariaLabel": string;
         /**
           * URL or identifier of an audio file associated with the container.
-          * @default ''
          */
         "audio": string;
         /**
           * Base URL for the container.
-          * @default ''
          */
         "baseUrl": string;
         /**
           * Background color of the container (CSS color value).
-          * @default ''
          */
         "bgColor": string;
         /**
           * The background image URL to be applied to the entire body.
-          * @default ''
          */
         "bgImage": string;
         /**
           * Boolean that controls the playability of the game.
-          * @default true
          */
         "canplay": boolean;
         /**
           * Custom CSS styles to be applied to the container. Allows for dynamic styling through inline styles or class names.
-          * @default ''
          */
         "customStyle": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
@@ -478,27 +411,22 @@ export namespace Components {
         "exitButtonUrl": string;
         /**
           * The height of the container (CSS value).
-          * @default 'auto'
          */
         "height": string;
         /**
           * Unique identifier for the container.
-          * @default ''
          */
         "id": string;
         /**
           * Determines if the activity should proceed automatically only after a correct response. Acceptable values: "true" or "false". Defaults to "false".
-          * @default false
          */
         "isAllowOnlyCorrect": boolean;
         /**
           * Specifies whether the activity should continue automatically upon a correct response. Expected values: "true" or "false".
-          * @default false
          */
         "isContinueOnCorrect": boolean;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
@@ -507,27 +435,22 @@ export namespace Components {
         "nextButtonUrl": string;
         /**
           * Objective or purpose of the container. Can be used for internal logic or tracking.
-          * @default ''
          */
         "objective": string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler triggered when the container is entered, useful for triggering animations or logic.
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler triggered when the container is touched or clicked.
-          * @default ''
          */
         "onTouch": string;
         /**
@@ -536,22 +459,18 @@ export namespace Components {
         "prevButtonUrl": string;
         /**
           * Indicates whether the "Check" button should be visible or not. Expected values: "true" or "false".
-          * @default false
          */
         "showCheck": boolean;
         /**
           * Controls whether the drop zone displays a border; true shows the border, false hides it.
-          * @default true
          */
         "showDropBorder": boolean;
         /**
           * Indicates whether the next button should be displayed. Expected values: "true" or "false".
-          * @default 'false'
          */
         "showNextButton": string;
         /**
           * Indicates whether the previous button should be displayed. Expected values: "true" or "false".
-          * @default 'false'
          */
         "showPrevButton": string;
         /**
@@ -560,59 +479,48 @@ export namespace Components {
         "speakerButtonUrl": string;
         /**
           * TabIndex for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * Type of the container, which can be used for conditional logic or styling purposes.
-          * @default ''
          */
         "type": string;
         /**
           * Value assigned to the container. This can be used for logic related to this component.
-          * @default ''
          */
         "value": string;
         /**
           * Visibility flag for the container. If `true`, the container is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible": boolean;
         /**
           * The width of the container (CSS value).
-          * @default 'auto'
          */
         "width": string;
         /**
           * X-axis (horizontal) position of the container.
-          * @default '0px'
          */
         "x": string;
         /**
           * Y-axis (vertical) position of the container.
-          * @default '0px'
          */
         "y": string;
         /**
           * Z-index to control the stacking order of the container.
-          * @default '0'
          */
         "z": string;
     }
     interface LidoFlashCard {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * Audio file URL or identifier for sound that will be associated with the column.
-          * @default ''
          */
         "audio": string;
         /**
@@ -621,12 +529,10 @@ export namespace Components {
         "back": any;
         /**
           * Background color of the column (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
@@ -639,7 +545,6 @@ export namespace Components {
         "display"?: string;
         /**
           * Whether the card is flipped (back side visible). `mutable` lets the component toggle itself on click; `reflect` keeps the `<lido-flash-card flipped>` attribute in sync.
-          * @default false
          */
         "flipped": boolean;
         /**
@@ -648,72 +553,58 @@ export namespace Components {
         "front": any;
         /**
           * The height of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler triggered when the column is entered, useful for triggering animations or logic.
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler for a touch event, where a custom function can be triggered when the column is touched.
-          * @default ''
          */
         "onTouch": string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * Defines the type of the column, which can be used for styling or specific logic handling.
-          * @default ''
          */
         "type": string;
         /**
           * The value associated with the column component. Typically used for internal logic.
-          * @default ''
          */
         "value": string;
         /**
           * A boolean that controls whether the column is visible (`true`) or hidden (`false`).
-          * @default true
          */
         "visible": boolean;
         /**
           * The width of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width": string;
         /**
           * X-axis (horizontal) position of the column within its container (CSS value, e.g., '10px', '5%').
-          * @default '0px'
          */
         "x": string;
         /**
           * Y-axis (vertical) position of the column within its container (CSS value, e.g., '10px', '5%').
-          * @default '0px'
          */
         "y": string;
         /**
           * Z-index for stacking order of the column relative to other elements.
-          * @default '0'
          */
         "z": string;
     }
@@ -724,12 +615,10 @@ export namespace Components {
         "bgColor": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * Direction of the float element's movement (e.g., 'leftToRight', 'bottomToTop'). This can be used to control the animation or positioning of the float elements.
-          * @default 'bottomToTop'
          */
         "floatDirection": string;
         /**
@@ -738,17 +627,14 @@ export namespace Components {
         "height": string;
         /**
           * Unique identifier for the text element.
-          * @default ''
          */
         "id": string;
         /**
           * Event handler triggered when the text component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry": string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
@@ -757,12 +643,10 @@ export namespace Components {
         "type": string;
         /**
           * Value associated with the text element, typically used for internal logic or tracking.
-          * @default ''
          */
         "value": string;
         /**
           * Controls the visibility of the text component. If `true`, the text is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible": boolean;
         /**
@@ -771,7 +655,6 @@ export namespace Components {
         "width": string;
         /**
           * Z-index for stacking order of the text component relative to other elements.
-          * @default '0'
          */
         "z": string;
     }
@@ -788,12 +671,10 @@ export namespace Components {
         "avatarUrl": string;
         /**
           * Base URL for the containers.
-          * @default ''
          */
         "baseUrl": string;
         /**
           * Boolean that controls the playability of the game.
-          * @default true
          */
         "canplay": boolean;
         /**
@@ -802,12 +683,10 @@ export namespace Components {
         "exitButtonUrl": string;
         /**
           * The height of the container (CSS value).
-          * @default ''
          */
         "height": string;
         /**
           * Initial index of the container being displayed.
-          * @default 0
          */
         "initialIndex": number;
         /**
@@ -828,7 +707,6 @@ export namespace Components {
         "uuid": string;
         /**
           * XML data passed to the component, which is parsed and used to render various containers.
-          * @default ''
          */
         "xmlData": string;
     }
@@ -858,17 +736,14 @@ export namespace Components {
         "bgColor": string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * CSS filter to apply visual effects (e.g., blur, brightness) to the image. Example: 'blur(5px)', 'brightness(0.8)', 'grayscale(100%)'
-          * @default ''
          */
         "filter": string;
         /**
@@ -885,17 +760,14 @@ export namespace Components {
         "isSlice": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
@@ -916,17 +788,14 @@ export namespace Components {
         "onTouch": string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
           * Specifies the width for border-image slice (e.g., "30px", "2em"). Only used when `isSlice` is enabled.
-          * @default '30px'
          */
         "sliceWidth": string;
         /**
@@ -939,7 +808,6 @@ export namespace Components {
         "tabIndex": number;
         /**
           * CSS transform property to apply transformations like rotate, scale, translate, etc. Example: 'rotate(45deg)' or 'scale(1.2)'.
-          * @default ''
          */
         "transform": string;
         /**
@@ -974,17 +842,14 @@ export namespace Components {
     interface LidoKeyboard {
         /**
           * Background color for each key button
-          * @default ''
          */
         "bgColor": string;
         /**
           * Border radius for key buttons (e.g., "8px")
-          * @default ''
          */
         "borderRadius": string;
         /**
           * Number of columns in the keyboard layout (default: "10")
-          * @default '10'
          */
         "columns": string;
         /**
@@ -1001,7 +866,6 @@ export namespace Components {
         "fontSize"?: string;
         /**
           * Gap between key buttons (default: "10px")
-          * @default '10px'
          */
         "gap": string;
         /**
@@ -1010,12 +874,10 @@ export namespace Components {
         "height"?: string;
         /**
           * Indicates whether the keyboard input is enabled. When set to `true`, the component will respond to keyboard events.
-          * @default false
          */
         "keyboardInput": boolean;
         /**
           * Comma-separated list of keys, optionally with status (e.g., "A,B-disable,C")
-          * @default ''
          */
         "keys": string;
         /**
@@ -1068,107 +930,86 @@ export namespace Components {
     interface LidoPos {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * URL or identifier for an audio file associated with the component.
-          * @default ''
          */
         "audio": string;
         /**
           * Background color of the component (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor": string;
         /**
           * The height of the component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height": string;
         /**
           * Unique identifier for the positional element.
-          * @default ''
          */
         "id": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler triggered when the component is entered, often used to trigger animations or custom logic.
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler triggered when the component is touched or clicked.
-          * @default ''
          */
         "onTouch": string;
         /**
           * Tab index to support keyboard navigation within the component.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * The type of the component, used for conditional logic or specific styles.
-          * @default ''
          */
         "type": string;
         /**
           * Value assigned to the component, often used for internal logic or data tracking.
-          * @default ''
          */
         "value": string;
         /**
           * Visibility flag to control whether the element is displayed (`true`) or hidden (`false`).
-          * @default false
          */
         "visible": boolean | string;
         /**
           * The width of the component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width": string;
         /**
           * X-axis (horizontal) position of the component (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x": string;
         /**
           * Y-axis (vertical) position of the component (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y": string;
         /**
           * Z-index for stacking order of the element relative to others.
-          * @default '0'
          */
         "z": string;
     }
@@ -1181,112 +1022,90 @@ export namespace Components {
     interface LidoRandom {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * URL or identifier for an audio file associated with the component.
-          * @default ''
          */
         "audio": string;
         /**
           * Background color of the container (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor": string;
         /**
           * The height of the container (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height": string;
         /**
           * Unique identifier for the random container.
-          * @default ''
          */
         "id": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler triggered when the component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler triggered when the component is touched or clicked.
-          * @default ''
          */
         "onTouch": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * The type of the component, used for conditional logic or specific styling.
-          * @default ''
          */
         "type": string;
         /**
           * Value associated with the component, often used for internal logic.
-          * @default ''
          */
         "value": string;
         /**
           * Controls the visibility of the container. If `true`, the container is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible": boolean;
         /**
           * The width of the container (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width": string;
         /**
           * X-axis (horizontal) position of the container (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x": string;
         /**
           * Y-axis (vertical) position of the container (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y": string;
         /**
           * Z-index for stacking order of the container relative to other elements.
-          * @default '0'
          */
         "z": string;
     }
@@ -1299,12 +1118,10 @@ export namespace Components {
     interface LidoRoot {
         /**
           * Base URL for the containers.
-          * @default ''
          */
         "baseUrl": string;
         /**
           * Boolean that controls the playability of the game.
-          * @default true
          */
         "canplay": boolean;
         /**
@@ -1313,12 +1130,10 @@ export namespace Components {
         "exitButtonUrl": string;
         /**
           * Initial index of the container being displayed.
-          * @default 0
          */
         "initialIndex": number;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
@@ -1335,7 +1150,6 @@ export namespace Components {
         "speakerButtonUrl": string;
         /**
           * Prop to hold the XML file path or URL. This can be a relative path or an external URL.
-          * @default ''
          */
         "xmlPath": string;
     }
@@ -1379,12 +1193,10 @@ export namespace Components {
         "height": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
@@ -1393,7 +1205,6 @@ export namespace Components {
         "maxLength": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
@@ -1418,7 +1229,6 @@ export namespace Components {
         "onTouch": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
@@ -1463,117 +1273,94 @@ export namespace Components {
     interface LidoShape {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * URL or identifier for an audio file associated with the shape.
-          * @default ''
          */
         "audio": string;
         /**
           * Background color of the shape (CSS color value, e.g., '#FFFFFF', 'blue'). This is ignored for polygons.
-          * @default ''
          */
         "bgColor": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * The height of the shape (CSS value, e.g., '100px', '50%'). This is ignored for polygons.
-          * @default 'auto'
          */
         "height": string;
         /**
           * Unique identifier for the shape element.
-          * @default ''
          */
         "id": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler triggered when the shape is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler triggered when the shape is touched or clicked.
-          * @default ''
          */
         "onTouch": string;
         /**
           * Type of shape to render (e.g., 'circle', 'rectangle', 'polygon').
-          * @default 'circle'
          */
         "shapeType": string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * Defines the type of the shape, which can be used for conditional logic or specific styling.
-          * @default ''
          */
         "type": string;
         /**
           * Value associated with the shape, typically used for internal logic or tracking.
-          * @default ''
          */
         "value": string;
         /**
           * Controls the visibility of the shape. If `true`, the shape is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible": boolean;
         /**
           * The width of the shape (CSS value, e.g., '100px', '50%'). This is ignored for polygons.
-          * @default 'auto'
          */
         "width": string;
         /**
           * X-axis (horizontal) position of the shape (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x": string;
         /**
           * Y-axis (vertical) position of the shape (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y": string;
         /**
           * Z-index for stacking order of the shape relative to other elements.
-          * @default '0'
          */
         "z": string;
     }
@@ -1584,17 +1371,14 @@ export namespace Components {
         "bgColor": string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * Number of divisions or segments to split the ruler path into
-          * @default 5
          */
         "division": number;
         /**
@@ -1611,7 +1395,6 @@ export namespace Components {
         "height": string;
         /**
           * Unique identifier for the component instance
-          * @default 'lido-slide-fill'
          */
         "id": string;
         /**
@@ -1620,27 +1403,22 @@ export namespace Components {
         "margin": string;
         /**
           * Maximum value shown on the ruler (used for number generation)
-          * @default 10
          */
         "max": number;
         /**
           * Minimum value shown on the ruler (used for number generation)
-          * @default 0
          */
         "min": number;
         /**
           * Type of number to be displayed on the ruler. Can be 'integer', 'decimal', or 'fraction'.
-          * @default 'integer'
          */
         "numberType": string;
         /**
           * Event handler triggered when the text component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry": string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding": string;
         /**
@@ -1653,7 +1431,6 @@ export namespace Components {
         "src": string;
         /**
           * Defines the type of the component, which can be used for conditional logic or specific styling.
-          * @default ''
          */
         "type": string;
         /**
@@ -1686,209 +1463,168 @@ export namespace Components {
     interface LidoText {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * URL or identifier for an audio file associated with the text component.
-          * @default ''
          */
         "audio": string;
         /**
           * Background color of the text component (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor": string;
         /**
           * The border image of the column (CSS border-image value, e.g., 'url(border.png)', 'linear-gradient(red, blue)').
-          * @default ''
          */
         "borderImage"?: string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * Font color for the text (CSS color value, e.g., '#000000', 'red').
-          * @default ''
          */
         "fontColor": string;
         /**
           * Font family for the text (CSS value, e.g., 'Arial', 'Times New Roman').
-          * @default ''
          */
         "fontFamily": string;
         /**
           * Font size for the text (CSS value, e.g., '16px', '1.5em').
-          * @default '20px'
          */
         "fontSize": string;
         /**
           * Height of the text component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height": string;
         /**
           * When set to `true`, the text will highlight while being spoken, typically used for accessibility.
-          * @default false
          */
         "highlightWhileSpeaking": boolean;
         /**
           * Unique identifier for the text element.
-          * @default ''
          */
         "id": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect": string;
         /**
           * Event handler triggered when the text component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry": string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect": string;
         /**
           * Event handler triggered when the text component is touched or clicked.
-          * @default ''
          */
         "onTouch": string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
           * Indicates whether to wrap each letter or each word of the text in a span element. This can be useful for animations or styling individual letters.
-          * @default ''
          */
         "spanType": 'letters' | 'words' | '';
         /**
           * The string of text to be displayed in the component.
-          * @default ''
          */
         "string": string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * Defines the type of the component, which can be used for conditional logic or specific styling.
-          * @default ''
          */
         "type": string;
         /**
           * Value associated with the text element, typically used for internal logic or tracking.
-          * @default ''
          */
         "value": string;
         /**
           * Controls the visibility of the text component. If `true`, the text is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible": boolean | string;
         /**
           * Width of the text component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width": string;
         /**
           * X-axis (horizontal) position of the text component (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x": string;
         /**
           * Y-axis (vertical) position of the text component (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y": string;
         /**
           * Z-index for stacking order of the text component relative to other elements.
-          * @default '0'
          */
         "z": string;
     }
     interface LidoTrace {
         /**
           * Indicates whether to play an animation trace when the SVG is completed.
-          * @default false
          */
         "animationTrace": boolean;
         /**
           * Controls visibility for assistive technologies. If `"true"`, the component is hidden from screen readers.
-          * @default ''
          */
         "ariaHidden": string;
         /**
           * Accessible label for screen readers, providing a textual description of the component's purpose.
-          * @default ''
          */
         "ariaLabel": string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible": string;
         /**
           * URL for the finger hint image
-          * @default 'https://aeakbcdznktpsbrfsgys.supabase.co/storage/v1/object/public/template-assets/trace/Tracing-hand.svg'
          */
         "fingerHintUrl": string;
         /**
           * Specifies the height of the component container, accepts any valid CSS height value (e.g., `"100px"`, `"50%"`).
-          * @default 'auto'
          */
         "height": string;
         /**
           * Indicates whether to highlight the text associated with the SVG when the trace is completed.
-          * @default ''
          */
         "highlightTextId": string;
         /**
           * Unique identifier for this `lido-trace` component instance.
-          * @default ''
          */
         "id": string;
         /**
           * Mode for the tracing interaction, defining how users interact with the SVG paths. Options may include `"noFlow"`, `"showFlow"`, `"freeTrace"`, `"blindTracing"`, and `"blindFreeTrace"`
-          * @default TraceMode.ShowFlow
          */
         "mode": string;
         /**
@@ -1901,42 +1637,34 @@ export namespace Components {
         "onInCorrect": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
           * Source URL or path for the SVG file used in this component.
-          * @default ''
          */
         "svgSource": string;
         /**
           * Sets the tab order of the component within the page, enabling keyboard navigation.
-          * @default 0
          */
         "tabIndex": number;
         /**
           * A custom string value associated with the component for additional data or identification.
-          * @default ''
          */
         "value": string;
         /**
           * Specifies the width of the component container, accepts any valid CSS width value (e.g., `"100px"`, `"50%"`).
-          * @default 'auto'
          */
         "width": string;
         /**
           * Defines the x-coordinate position (left offset) of the component container, using any valid CSS `left` value (e.g., `"10px"`, `"5%"`).
-          * @default '0px'
          */
         "x": string;
         /**
           * Defines the y-coordinate position (top offset) of the component container, using any valid CSS `top` value (e.g., `"10px"`, `"5%"`).
-          * @default '0px'
          */
         "y": string;
         /**
           * Sets the z-index of the component, controlling its stacking order on the page.
-          * @default '0'
          */
         "z": string;
     }
@@ -1981,12 +1709,10 @@ export namespace Components {
         "id": string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin": string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops": number;
         /**
@@ -1995,7 +1721,6 @@ export namespace Components {
         "maxLength": number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops": number;
         /**
@@ -2020,7 +1745,6 @@ export namespace Components {
         "onTouch": string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element.
-          * @default false
          */
         "showSpeakIcon": boolean;
         /**
@@ -2281,102 +2005,82 @@ declare namespace LocalJSX {
     interface LidoAvatar {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * Audio file URL or identifier for sound that will be associated with the column.
-          * @default ''
          */
         "audio"?: string;
         /**
           * The background color of the column (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * The height of the column component (CSS value, e.g., '100px', '50%').
-          * @default ''
          */
         "height"?: string;
         /**
           * The unique identifier for the column component.
-          * @default ''
          */
         "id"?: string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler for when the column is entered, which can be used to initiate specific behaviors on entry.
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler for a touch event, where a custom function can be triggered when the column is touched.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * Source URL of the Rive (.riv) file
-          * @default ''
          */
         "src"?: string;
         /**
           * The tab index value, used to set the tab order of the column for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * Defines the type of the column, which can be used for styling or specific logic handling.
-          * @default ''
          */
         "type"?: string;
         /**
           * The value associated with the column component. Typically used for internal logic.
-          * @default ''
          */
         "value"?: string;
         /**
           * A boolean that controls whether the column is visible (`true`) or hidden (`false`).
-          * @default false
          */
         "visible"?: boolean;
         /**
           * The width of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * The x-coordinate (left position) of the column within its container (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * The y-coordinate (top position) of the column within its container (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * The z-index of the column to control stacking order.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -2389,167 +2093,134 @@ declare namespace LocalJSX {
     interface LidoCell {
         /**
           * CSS align-items property to control the alignment of flex items. Example: 'flex-start', 'flex-end', 'center', 'baseline', 'stretch'.
-          * @default ''
          */
         "alignItems"?: string;
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * Audio file URL or identifier for sound that will be associated with the column.
-          * @default ''
          */
         "audio"?: string;
         /**
           * The background color of the column (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius"?: string;
         /**
           * The number of child elements that should be displayed inside the row. This value is dynamically adjusted based on `minLength` and `maxLength`.
-          * @default 9999
          */
         "childElementsLength"?: number;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * CSS flex direction for the component, which can be used to control the layout of child elements. Accepts values like 'row', 'column', etc.
-          * @default ''
          */
         "flexDirection"?: string;
         /**
           * The gap between child elements inside the column (CSS value, e.g., '10px', '5px 10px'). This is applicable when the layout is set to `wrap` or `flex`.
-          * @default '0'
          */
         "gap"?: string;
         /**
           * The height of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * The unique identifier for the column component.
-          * @default ''
          */
         "id"?: string;
         /**
           * Determines the layout behavior of the component's children.  - `wrap`: Applies a grid layout to the children, allowing them to wrap automatically in a grid format. - `flex`: Applies a flex layout with wrapping behavior (`flex-wrap`). - `col`: Arranges children in a single column using a vertical flex direction. - `row`: Arranges children in a single row using a horizontal flex direction. - `pos`: Applies absolute positioning to children, allowing manual placement using `x` and `y` values. - `random`: Positions child elements randomly within the container using absolute positioning.  Default: `'wrap'`
-          * @default 'wrap'
          */
         "layout"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
           * The maximum number of child elements that can be displayed inside the row. If `childElementsLength` exceeds this value, excess elements will be hidden.
-          * @default 9999
          */
         "maxLength"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
           * The minimum number of child elements that must be displayed inside the row. If `childElementsLength` is less than this value, additional elements may be shown to meet this minimum.
-          * @default 0
          */
         "minLength"?: number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler for when the column is entered, which can be used to initiate specific behaviors on entry.
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler for a touch event, where a custom function can be triggered when the column is touched.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding"?: string;
         /**
           * Defines the width of the scrollbar within the cell (e.g., '14px'). Defaults to '0px' if not specified, effectively hiding the scrollbar.
-          * @default ''
          */
         "scrollbarWidth"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
           * The tab index value, used to set the tab order of the column for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * Defines the type of the column, which can be used for styling or specific logic handling.
-          * @default ''
          */
         "type"?: string;
         /**
           * The value associated with the column component. Typically used for internal logic.
-          * @default ''
          */
         "value"?: string;
         /**
           * A boolean that controls whether the column is visible (`true`) or hidden (`false`).
-          * @default 'false'
          */
         "visible"?: string;
         /**
           * The width of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * The x-coordinate (left position) of the column within its container (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * The y-coordinate (top position) of the column within its container (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * The z-index of the column to control stacking order.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -2604,12 +2275,10 @@ declare namespace LocalJSX {
         "id"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
@@ -2618,7 +2287,6 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
@@ -2643,7 +2311,6 @@ declare namespace LocalJSX {
         "onTouch"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
@@ -2688,52 +2355,42 @@ declare namespace LocalJSX {
     interface LidoContainer {
         /**
           * Enables appending the dragged element to the drop target after all correct drops are completed.
-          * @default false
          */
         "appendToDropOnCompletion"?: boolean;
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default 'auto'
          */
         "ariaLabel"?: string;
         /**
           * URL or identifier of an audio file associated with the container.
-          * @default ''
          */
         "audio"?: string;
         /**
           * Base URL for the container.
-          * @default ''
          */
         "baseUrl"?: string;
         /**
           * Background color of the container (CSS color value).
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * The background image URL to be applied to the entire body.
-          * @default ''
          */
         "bgImage"?: string;
         /**
           * Boolean that controls the playability of the game.
-          * @default true
          */
         "canplay"?: boolean;
         /**
           * Custom CSS styles to be applied to the container. Allows for dynamic styling through inline styles or class names.
-          * @default ''
          */
         "customStyle"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
@@ -2742,27 +2399,22 @@ declare namespace LocalJSX {
         "exitButtonUrl"?: string;
         /**
           * The height of the container (CSS value).
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * Unique identifier for the container.
-          * @default ''
          */
         "id"?: string;
         /**
           * Determines if the activity should proceed automatically only after a correct response. Acceptable values: "true" or "false". Defaults to "false".
-          * @default false
          */
         "isAllowOnlyCorrect"?: boolean;
         /**
           * Specifies whether the activity should continue automatically upon a correct response. Expected values: "true" or "false".
-          * @default false
          */
         "isContinueOnCorrect"?: boolean;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
@@ -2771,27 +2423,22 @@ declare namespace LocalJSX {
         "nextButtonUrl"?: string;
         /**
           * Objective or purpose of the container. Can be used for internal logic or tracking.
-          * @default ''
          */
         "objective"?: string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler triggered when the container is entered, useful for triggering animations or logic.
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler triggered when the container is touched or clicked.
-          * @default ''
          */
         "onTouch"?: string;
         /**
@@ -2800,22 +2447,18 @@ declare namespace LocalJSX {
         "prevButtonUrl"?: string;
         /**
           * Indicates whether the "Check" button should be visible or not. Expected values: "true" or "false".
-          * @default false
          */
         "showCheck"?: boolean;
         /**
           * Controls whether the drop zone displays a border; true shows the border, false hides it.
-          * @default true
          */
         "showDropBorder"?: boolean;
         /**
           * Indicates whether the next button should be displayed. Expected values: "true" or "false".
-          * @default 'false'
          */
         "showNextButton"?: string;
         /**
           * Indicates whether the previous button should be displayed. Expected values: "true" or "false".
-          * @default 'false'
          */
         "showPrevButton"?: string;
         /**
@@ -2824,59 +2467,48 @@ declare namespace LocalJSX {
         "speakerButtonUrl"?: string;
         /**
           * TabIndex for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * Type of the container, which can be used for conditional logic or styling purposes.
-          * @default ''
          */
         "type"?: string;
         /**
           * Value assigned to the container. This can be used for logic related to this component.
-          * @default ''
          */
         "value"?: string;
         /**
           * Visibility flag for the container. If `true`, the container is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible"?: boolean;
         /**
           * The width of the container (CSS value).
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * X-axis (horizontal) position of the container.
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Y-axis (vertical) position of the container.
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Z-index to control the stacking order of the container.
-          * @default '0'
          */
         "z"?: string;
     }
     interface LidoFlashCard {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * Audio file URL or identifier for sound that will be associated with the column.
-          * @default ''
          */
         "audio"?: string;
         /**
@@ -2885,12 +2517,10 @@ declare namespace LocalJSX {
         "back"?: any;
         /**
           * Background color of the column (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
@@ -2903,7 +2533,6 @@ declare namespace LocalJSX {
         "display"?: string;
         /**
           * Whether the card is flipped (back side visible). `mutable` lets the component toggle itself on click; `reflect` keeps the `<lido-flash-card flipped>` attribute in sync.
-          * @default false
          */
         "flipped"?: boolean;
         /**
@@ -2912,72 +2541,58 @@ declare namespace LocalJSX {
         "front"?: any;
         /**
           * The height of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler triggered when the column is entered, useful for triggering animations or logic.
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler for a touch event, where a custom function can be triggered when the column is touched.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * Defines the type of the column, which can be used for styling or specific logic handling.
-          * @default ''
          */
         "type"?: string;
         /**
           * The value associated with the column component. Typically used for internal logic.
-          * @default ''
          */
         "value"?: string;
         /**
           * A boolean that controls whether the column is visible (`true`) or hidden (`false`).
-          * @default true
          */
         "visible"?: boolean;
         /**
           * The width of the column component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * X-axis (horizontal) position of the column within its container (CSS value, e.g., '10px', '5%').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Y-axis (vertical) position of the column within its container (CSS value, e.g., '10px', '5%').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Z-index for stacking order of the column relative to other elements.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -2988,12 +2603,10 @@ declare namespace LocalJSX {
         "bgColor"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * Direction of the float element's movement (e.g., 'leftToRight', 'bottomToTop'). This can be used to control the animation or positioning of the float elements.
-          * @default 'bottomToTop'
          */
         "floatDirection"?: string;
         /**
@@ -3002,17 +2615,14 @@ declare namespace LocalJSX {
         "height"?: string;
         /**
           * Unique identifier for the text element.
-          * @default ''
          */
         "id"?: string;
         /**
           * Event handler triggered when the text component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
@@ -3021,12 +2631,10 @@ declare namespace LocalJSX {
         "type"?: string;
         /**
           * Value associated with the text element, typically used for internal logic or tracking.
-          * @default ''
          */
         "value"?: string;
         /**
           * Controls the visibility of the text component. If `true`, the text is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible"?: boolean;
         /**
@@ -3035,7 +2643,6 @@ declare namespace LocalJSX {
         "width"?: string;
         /**
           * Z-index for stacking order of the text component relative to other elements.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -3052,12 +2659,10 @@ declare namespace LocalJSX {
         "avatarUrl"?: string;
         /**
           * Base URL for the containers.
-          * @default ''
          */
         "baseUrl"?: string;
         /**
           * Boolean that controls the playability of the game.
-          * @default true
          */
         "canplay"?: boolean;
         /**
@@ -3066,12 +2671,10 @@ declare namespace LocalJSX {
         "exitButtonUrl"?: string;
         /**
           * The height of the container (CSS value).
-          * @default ''
          */
         "height"?: string;
         /**
           * Initial index of the container being displayed.
-          * @default 0
          */
         "initialIndex"?: number;
         /**
@@ -3092,7 +2695,6 @@ declare namespace LocalJSX {
         "uuid"?: string;
         /**
           * XML data passed to the component, which is parsed and used to render various containers.
-          * @default ''
          */
         "xmlData"?: string;
     }
@@ -3122,17 +2724,14 @@ declare namespace LocalJSX {
         "bgColor"?: string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * CSS filter to apply visual effects (e.g., blur, brightness) to the image. Example: 'blur(5px)', 'brightness(0.8)', 'grayscale(100%)'
-          * @default ''
          */
         "filter"?: string;
         /**
@@ -3149,17 +2748,14 @@ declare namespace LocalJSX {
         "isSlice"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
@@ -3180,17 +2776,14 @@ declare namespace LocalJSX {
         "onTouch"?: string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
           * Specifies the width for border-image slice (e.g., "30px", "2em"). Only used when `isSlice` is enabled.
-          * @default '30px'
          */
         "sliceWidth"?: string;
         /**
@@ -3203,7 +2796,6 @@ declare namespace LocalJSX {
         "tabIndex"?: number;
         /**
           * CSS transform property to apply transformations like rotate, scale, translate, etc. Example: 'rotate(45deg)' or 'scale(1.2)'.
-          * @default ''
          */
         "transform"?: string;
         /**
@@ -3238,17 +2830,14 @@ declare namespace LocalJSX {
     interface LidoKeyboard {
         /**
           * Background color for each key button
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * Border radius for key buttons (e.g., "8px")
-          * @default ''
          */
         "borderRadius"?: string;
         /**
           * Number of columns in the keyboard layout (default: "10")
-          * @default '10'
          */
         "columns"?: string;
         /**
@@ -3265,7 +2854,6 @@ declare namespace LocalJSX {
         "fontSize"?: string;
         /**
           * Gap between key buttons (default: "10px")
-          * @default '10px'
          */
         "gap"?: string;
         /**
@@ -3274,12 +2862,10 @@ declare namespace LocalJSX {
         "height"?: string;
         /**
           * Indicates whether the keyboard input is enabled. When set to `true`, the component will respond to keyboard events.
-          * @default false
          */
         "keyboardInput"?: boolean;
         /**
           * Comma-separated list of keys, optionally with status (e.g., "A,B-disable,C")
-          * @default ''
          */
         "keys"?: string;
         /**
@@ -3332,107 +2918,86 @@ declare namespace LocalJSX {
     interface LidoPos {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * URL or identifier for an audio file associated with the component.
-          * @default ''
          */
         "audio"?: string;
         /**
           * Background color of the component (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * The height of the component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * Unique identifier for the positional element.
-          * @default ''
          */
         "id"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler triggered when the component is entered, often used to trigger animations or custom logic.
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler triggered when the component is touched or clicked.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * Tab index to support keyboard navigation within the component.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * The type of the component, used for conditional logic or specific styles.
-          * @default ''
          */
         "type"?: string;
         /**
           * Value assigned to the component, often used for internal logic or data tracking.
-          * @default ''
          */
         "value"?: string;
         /**
           * Visibility flag to control whether the element is displayed (`true`) or hidden (`false`).
-          * @default false
          */
         "visible"?: boolean | string;
         /**
           * The width of the component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * X-axis (horizontal) position of the component (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Y-axis (vertical) position of the component (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Z-index for stacking order of the element relative to others.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -3445,112 +3010,90 @@ declare namespace LocalJSX {
     interface LidoRandom {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * URL or identifier for an audio file associated with the component.
-          * @default ''
          */
         "audio"?: string;
         /**
           * Background color of the container (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * The height of the container (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * Unique identifier for the random container.
-          * @default ''
          */
         "id"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler triggered when the component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler triggered when the component is touched or clicked.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * The type of the component, used for conditional logic or specific styling.
-          * @default ''
          */
         "type"?: string;
         /**
           * Value associated with the component, often used for internal logic.
-          * @default ''
          */
         "value"?: string;
         /**
           * Controls the visibility of the container. If `true`, the container is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible"?: boolean;
         /**
           * The width of the container (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * X-axis (horizontal) position of the container (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Y-axis (vertical) position of the container (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Z-index for stacking order of the container relative to other elements.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -3563,12 +3106,10 @@ declare namespace LocalJSX {
     interface LidoRoot {
         /**
           * Base URL for the containers.
-          * @default ''
          */
         "baseUrl"?: string;
         /**
           * Boolean that controls the playability of the game.
-          * @default true
          */
         "canplay"?: boolean;
         /**
@@ -3577,12 +3118,10 @@ declare namespace LocalJSX {
         "exitButtonUrl"?: string;
         /**
           * Initial index of the container being displayed.
-          * @default 0
          */
         "initialIndex"?: number;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
@@ -3599,7 +3138,6 @@ declare namespace LocalJSX {
         "speakerButtonUrl"?: string;
         /**
           * Prop to hold the XML file path or URL. This can be a relative path or an external URL.
-          * @default ''
          */
         "xmlPath"?: string;
     }
@@ -3643,12 +3181,10 @@ declare namespace LocalJSX {
         "height"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
@@ -3657,7 +3193,6 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
@@ -3682,7 +3217,6 @@ declare namespace LocalJSX {
         "onTouch"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
@@ -3727,117 +3261,94 @@ declare namespace LocalJSX {
     interface LidoShape {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * URL or identifier for an audio file associated with the shape.
-          * @default ''
          */
         "audio"?: string;
         /**
           * Background color of the shape (CSS color value, e.g., '#FFFFFF', 'blue'). This is ignored for polygons.
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * The height of the shape (CSS value, e.g., '100px', '50%'). This is ignored for polygons.
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * Unique identifier for the shape element.
-          * @default ''
          */
         "id"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler triggered when the shape is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler triggered when the shape is touched or clicked.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * Type of shape to render (e.g., 'circle', 'rectangle', 'polygon').
-          * @default 'circle'
          */
         "shapeType"?: string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * Defines the type of the shape, which can be used for conditional logic or specific styling.
-          * @default ''
          */
         "type"?: string;
         /**
           * Value associated with the shape, typically used for internal logic or tracking.
-          * @default ''
          */
         "value"?: string;
         /**
           * Controls the visibility of the shape. If `true`, the shape is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible"?: boolean;
         /**
           * The width of the shape (CSS value, e.g., '100px', '50%'). This is ignored for polygons.
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * X-axis (horizontal) position of the shape (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Y-axis (vertical) position of the shape (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Z-index for stacking order of the shape relative to other elements.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -3848,17 +3359,14 @@ declare namespace LocalJSX {
         "bgColor"?: string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * Number of divisions or segments to split the ruler path into
-          * @default 5
          */
         "division"?: number;
         /**
@@ -3875,7 +3383,6 @@ declare namespace LocalJSX {
         "height"?: string;
         /**
           * Unique identifier for the component instance
-          * @default 'lido-slide-fill'
          */
         "id"?: string;
         /**
@@ -3884,27 +3391,22 @@ declare namespace LocalJSX {
         "margin"?: string;
         /**
           * Maximum value shown on the ruler (used for number generation)
-          * @default 10
          */
         "max"?: number;
         /**
           * Minimum value shown on the ruler (used for number generation)
-          * @default 0
          */
         "min"?: number;
         /**
           * Type of number to be displayed on the ruler. Can be 'integer', 'decimal', or 'fraction'.
-          * @default 'integer'
          */
         "numberType"?: string;
         /**
           * Event handler triggered when the text component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding"?: string;
         /**
@@ -3917,7 +3419,6 @@ declare namespace LocalJSX {
         "src"?: string;
         /**
           * Defines the type of the component, which can be used for conditional logic or specific styling.
-          * @default ''
          */
         "type"?: string;
         /**
@@ -3950,209 +3451,168 @@ declare namespace LocalJSX {
     interface LidoText {
         /**
           * The ARIA hidden attribute of the container. Used for accessibility to hide the element.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * The ARIA label of the container. Used for accessibility to indicate the purpose of the element.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * URL or identifier for an audio file associated with the text component.
-          * @default ''
          */
         "audio"?: string;
         /**
           * Background color of the text component (CSS color value, e.g., '#FFFFFF', 'blue').
-          * @default ''
          */
         "bgColor"?: string;
         /**
           * The border image of the column (CSS border-image value, e.g., 'url(border.png)', 'linear-gradient(red, blue)').
-          * @default ''
          */
         "borderImage"?: string;
         /**
           * CSS filter to apply border radius to the image. Example: '10px' for  images.
-          * @default '0px'
          */
         "borderRadius"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * Font color for the text (CSS color value, e.g., '#000000', 'red').
-          * @default ''
          */
         "fontColor"?: string;
         /**
           * Font family for the text (CSS value, e.g., 'Arial', 'Times New Roman').
-          * @default ''
          */
         "fontFamily"?: string;
         /**
           * Font size for the text (CSS value, e.g., '16px', '1.5em').
-          * @default '20px'
          */
         "fontSize"?: string;
         /**
           * Height of the text component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * When set to `true`, the text will highlight while being spoken, typically used for accessibility.
-          * @default false
          */
         "highlightWhileSpeaking"?: boolean;
         /**
           * Unique identifier for the text element.
-          * @default ''
          */
         "id"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
           * Event handler for a Correct matching action, which can be used to hide the column or trigger other custom logic.
-          * @default ''
          */
         "onCorrect"?: string;
         /**
           * Event handler triggered when the text component is entered (useful for animations or logic on entry).
-          * @default ''
          */
         "onEntry"?: string;
         /**
           * Event handler for an Incorrect matching action, which can be used to trigger custom logic when the action is incorrect.
-          * @default ''
          */
         "onInCorrect"?: string;
         /**
           * Event handler triggered when the text component is touched or clicked.
-          * @default ''
          */
         "onTouch"?: string;
         /**
           * CSS padding value applied to each child element inside the container. Accepts standard CSS padding formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "padding"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element if it is true.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
           * Indicates whether to wrap each letter or each word of the text in a span element. This can be useful for animations or styling individual letters.
-          * @default ''
          */
         "spanType"?: 'letters' | 'words' | '';
         /**
           * The string of text to be displayed in the component.
-          * @default ''
          */
         "string"?: string;
         /**
           * Tab index for keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * Defines the type of the component, which can be used for conditional logic or specific styling.
-          * @default ''
          */
         "type"?: string;
         /**
           * Value associated with the text element, typically used for internal logic or tracking.
-          * @default ''
          */
         "value"?: string;
         /**
           * Controls the visibility of the text component. If `true`, the text is visible; otherwise, it is hidden.
-          * @default false
          */
         "visible"?: boolean | string;
         /**
           * Width of the text component (CSS value, e.g., '100px', '50%').
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * X-axis (horizontal) position of the text component (CSS value, e.g., '10px', '5vw').
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Y-axis (vertical) position of the text component (CSS value, e.g., '10px', '5vh').
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Z-index for stacking order of the text component relative to other elements.
-          * @default '0'
          */
         "z"?: string;
     }
     interface LidoTrace {
         /**
           * Indicates whether to play an animation trace when the SVG is completed.
-          * @default false
          */
         "animationTrace"?: boolean;
         /**
           * Controls visibility for assistive technologies. If `"true"`, the component is hidden from screen readers.
-          * @default ''
          */
         "ariaHidden"?: string;
         /**
           * Accessible label for screen readers, providing a textual description of the component's purpose.
-          * @default ''
          */
         "ariaLabel"?: string;
         /**
           * Delay in milliseconds to make the cell visible after mount.
-          * @default ''
          */
         "delayVisible"?: string;
         /**
           * URL for the finger hint image
-          * @default 'https://aeakbcdznktpsbrfsgys.supabase.co/storage/v1/object/public/template-assets/trace/Tracing-hand.svg'
          */
         "fingerHintUrl"?: string;
         /**
           * Specifies the height of the component container, accepts any valid CSS height value (e.g., `"100px"`, `"50%"`).
-          * @default 'auto'
          */
         "height"?: string;
         /**
           * Indicates whether to highlight the text associated with the SVG when the trace is completed.
-          * @default ''
          */
         "highlightTextId"?: string;
         /**
           * Unique identifier for this `lido-trace` component instance.
-          * @default ''
          */
         "id"?: string;
         /**
           * Mode for the tracing interaction, defining how users interact with the SVG paths. Options may include `"noFlow"`, `"showFlow"`, `"freeTrace"`, `"blindTracing"`, and `"blindFreeTrace"`
-          * @default TraceMode.ShowFlow
          */
         "mode"?: string;
         /**
@@ -4165,42 +3625,34 @@ declare namespace LocalJSX {
         "onInCorrect"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**
           * Source URL or path for the SVG file used in this component.
-          * @default ''
          */
         "svgSource"?: string;
         /**
           * Sets the tab order of the component within the page, enabling keyboard navigation.
-          * @default 0
          */
         "tabIndex"?: number;
         /**
           * A custom string value associated with the component for additional data or identification.
-          * @default ''
          */
         "value"?: string;
         /**
           * Specifies the width of the component container, accepts any valid CSS width value (e.g., `"100px"`, `"50%"`).
-          * @default 'auto'
          */
         "width"?: string;
         /**
           * Defines the x-coordinate position (left offset) of the component container, using any valid CSS `left` value (e.g., `"10px"`, `"5%"`).
-          * @default '0px'
          */
         "x"?: string;
         /**
           * Defines the y-coordinate position (top offset) of the component container, using any valid CSS `top` value (e.g., `"10px"`, `"5%"`).
-          * @default '0px'
          */
         "y"?: string;
         /**
           * Sets the z-index of the component, controlling its stacking order on the page.
-          * @default '0'
          */
         "z"?: string;
     }
@@ -4245,12 +3697,10 @@ declare namespace LocalJSX {
         "id"?: string;
         /**
           * CSS margin value applied to each child element inside the container. Accepts standard CSS margin formats (e.g., '10px', '5px 10px', etc.).
-          * @default ''
          */
         "margin"?: string;
         /**
           * The Maximum number of drag elements that can be dropped inside the Drop element.
-          * @default 1
          */
         "maxDrops"?: number;
         /**
@@ -4259,7 +3709,6 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         /**
           * The minimum number of drag elements that must be dropped inside the Drop element.
-          * @default 1
          */
         "minDrops"?: number;
         /**
@@ -4284,7 +3733,6 @@ declare namespace LocalJSX {
         "onTouch"?: string;
         /**
           * Controls whether the speak icon should appear directly on the top right corner of targeted element.
-          * @default false
          */
         "showSpeakIcon"?: boolean;
         /**

--- a/src/components/home/lido-home.tsx
+++ b/src/components/home/lido-home.tsx
@@ -374,6 +374,7 @@ export class LidoHome {
       'lido-slide-fill': <lido-slide-fill {...props}>{children}</lido-slide-fill>,
       'lido-float': <lido-float {...props}>{children}</lido-float>,
       'lido-keyboard': <lido-keyboard {...props}>{children}</lido-keyboard>,
+      'lido-math-matrix': <lido-math-matrix {...props}>{children}</lido-math-matrix>,
     };
 
     // If the tag is known, return the corresponding Stencil component, otherwise log a warning

--- a/src/components/home/readme.md
+++ b/src/components/home/readme.md
@@ -46,6 +46,7 @@
 - [lido-slide-fill](../slideFill)
 - [lido-float](../float)
 - [lido-keyboard](../keyboard)
+- [lido-math-matrix](../mathMatrix)
 
 ### Graph
 ```mermaid
@@ -66,6 +67,7 @@ graph TD;
   lido-home --> lido-slide-fill
   lido-home --> lido-float
   lido-home --> lido-keyboard
+  lido-home --> lido-math-matrix
   lido-keyboard --> lido-text
   lido-root --> lido-home
   style lido-home fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/components/mathMatrix/lido-math-matrix.css
+++ b/src/components/mathMatrix/lido-math-matrix.css
@@ -1,0 +1,48 @@
+.math-matrix {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.slot {
+  width: 100%;
+  height: 100%;
+}
+
+.slot:hover {
+  /* background-color: rgba(0, 0, 0, 0.116); */
+  opacity: 0.7;
+}
+
+.slot-parent {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.slot-active {
+  background-color: var(--active-bg-color);
+  background-image: var(--bg-image);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.slot-deactive {
+  background-color: var(--deactive-bg-color);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.topIndex, .leftIndex, .bottomIndex {
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  align-content: center;
+  font-size: 30px;
+}

--- a/src/components/mathMatrix/lido-math-matrix.css
+++ b/src/components/mathMatrix/lido-math-matrix.css
@@ -32,8 +32,8 @@
   background-repeat: no-repeat;
 }
 
-.slot-deactive {
-  background-color: var(--deactive-bg-color);
+.slot-inactive {
+  background-color: var(--inactive-bg-color);
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/src/components/mathMatrix/lido-math-matrix.tsx
+++ b/src/components/mathMatrix/lido-math-matrix.tsx
@@ -38,7 +38,7 @@ export class LidoMathMatrix {
   @Prop() activeBgColor: string = 'red';
 
   /** Background color for inactive slots */
-  @Prop() deactiveBgColor: string = 'transparent';
+  @Prop() inactiveBgColor: string = 'transparent';
 
   /** Border style applied to each slot */
   @Prop() border: string = '2px solid green';
@@ -76,7 +76,7 @@ export class LidoMathMatrix {
     slotElements.forEach((el, i) => {
       const slot = el as HTMLElement;
       slot.style.setProperty('--active-bg-color', this.activeBgColor);
-      slot.style.setProperty('--deactive-bg-color', this.deactiveBgColor);
+      slot.style.setProperty('--inactive-bg-color', this.inactiveBgColor);
 
       this.clickable ? (slot.style.pointerEvents = '') : (slot.style.pointerEvents = 'none');
       slot.style.border = this.border;
@@ -155,13 +155,13 @@ export class LidoMathMatrix {
       const slotEl = el as HTMLElement;
       if (i < index) {
         slotEl.classList.add('slot-active');
-        slotEl.classList.remove('slot-deactive');
+        slotEl.classList.remove('slot-inactive');
         if (this.matrixImage) {
           slotEl.style.setProperty('--bg-image', `url(${convertUrlToRelative(this.matrixImage)})`);
         }
       } else {
         slotEl.classList.remove('slot-active');
-        slotEl.classList.add('slot-deactive');
+        slotEl.classList.add('slot-inactive');
       }
     });
   }
@@ -180,7 +180,7 @@ export class LidoMathMatrix {
                 <div class="leftIndex">{++colIndex}</div>
               ) : (
                 <div
-                  class={`slot slot-${slotNumber++} ${this.defualtFill + 1 >= slotNumber ? 'slot-active' : 'slot-deactive'}`}
+                  class={`slot slot-${slotNumber++} ${this.defualtFill + 1 >= slotNumber ? 'slot-active' : 'slot-inactive'}`}
                   onClick={() => this.handleClickSlot(event.target as HTMLElement)}
                   key={`slot-${rowIndex}-${colIndex}`}
                   style={{ borderRadius: this.style.borderRadius }}

--- a/src/components/mathMatrix/lido-math-matrix.tsx
+++ b/src/components/mathMatrix/lido-math-matrix.tsx
@@ -1,0 +1,198 @@
+import { Component, Host, Prop, State, h, Element } from '@stencil/core';
+import { convertUrlToRelative, parseProp } from '../../utils/utils';
+
+@Component({
+  tag: 'lido-math-matrix',
+  styleUrl: 'lido-math-matrix.css',
+  shadow: false,
+})
+export class LidoMathMatrix {
+  /** Number of rows in the matrix */
+  @Prop() rows = 7;
+
+  /** Number of columns in the matrix */
+  @Prop() cols = 5;
+
+  /** Number of slots to pre-fill as active by default */
+  @Prop() defualtFill = 0;
+
+  /** Show row index numbers on the left side */
+  @Prop() leftIndex = false;
+
+  /** Show column index numbers on the top side */
+  @Prop() topIndex = false;
+
+  /** Show row index numbers on the bottom side */
+  @Prop() bottomIndex = false;
+
+  /** Enable/disable click interactions on the slots */
+  @Prop() clickable = true;
+
+  /** If true, only active slots are visible; inactive ones are hidden */
+  @Prop() activeOnlyVisible = false;
+
+  /** Image source used inside the slots */
+  @Prop() matrixImage: string;
+
+  /** Background color for active slots */
+  @Prop() activeBgColor: string = 'red';
+
+  /** Background color for inactive slots */
+  @Prop() deactiveBgColor: string = 'transparent';
+
+  /** Border style applied to each slot */
+  @Prop() border: string = '2px solid green';
+
+  /** Height of the slot container */
+  @Prop() height: string = '100%';
+
+  /** Width of the slot container */
+  @Prop() width: string = '100%';
+
+  /** Border radius for each slot */
+  @Prop() borderRadius: string = '5px';
+
+  /** Z-index value for the matrix container */
+  @Prop() z: string;
+
+  /** Margin around the matrix container */
+  @Prop() margin: string;
+
+  /** Padding inside the matrix container */
+  @Prop() padding: string;
+
+  /** Controls visibility of the matrix (string "true" or "false") */
+  @Prop() visible: string = 'false';
+
+  /** Holds dynamically generated inline styles for the container */
+  @State() style: { [key: string]: string | undefined } = {};
+
+  /** Reference to the host element of this component */
+  @Element() el: HTMLElement;
+
+  componentDidLoad() {
+    const slotElements = this.el.querySelectorAll('.slot');
+
+    slotElements.forEach((el, i) => {
+      const slot = el as HTMLElement;
+      slot.style.setProperty('--active-bg-color', this.activeBgColor);
+      slot.style.setProperty('--deactive-bg-color', this.deactiveBgColor);
+
+      this.clickable ? (slot.style.pointerEvents = '') : (slot.style.pointerEvents = 'none');
+      slot.style.border = this.border;
+
+      if (slot.className.includes('slot-active')) {
+        slot.style.visibility = 'visible';
+        if (this.matrixImage) {
+          slot.style.setProperty('--bg-image', `url(${convertUrlToRelative(this.matrixImage)})`);
+        }
+      } else if (this.activeOnlyVisible) {
+        slot.style.visibility = 'hidden';
+      }
+    });
+
+    this.updateSlots();
+    this.updateStyles();
+  }
+
+
+  /**
+   * Lifecycle method that runs before the component is rendered.
+   * Initializes styles and sets up event listeners for resize and load events.
+   */
+  componentWillLoad() {
+    this.updateStyles();
+    this.updateSlots();
+    window.addEventListener('resize', this.updateStyles.bind(this));
+    window.addEventListener('load', this.updateStyles.bind(this));
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener('resize', this.updateStyles.bind(this));
+    window.removeEventListener('load', this.updateStyles.bind(this));
+  }
+
+  updateSlots() {
+    const slotElement = this.el.querySelectorAll('.slot');
+    const fristElement = this.el.querySelector('.slot') as HTMLElement;
+    if (!slotElement.length || !fristElement) return;
+    const slotMaxValues = fristElement.offsetWidth < fristElement.offsetHeight ? fristElement.offsetWidth : fristElement.offsetHeight;
+    const slotParent = this.el.querySelectorAll('.slot-parent');
+    slotParent.forEach(parent => {
+      (parent as HTMLElement).style.width = `${slotMaxValues}px`
+      Array.from(parent.children).forEach(el => {
+        const item = el as HTMLElement;
+        item.style.width = `${slotMaxValues}px`;
+        item.style.height = `${slotMaxValues}px`;
+
+        if (
+          (!this.topIndex && item.classList.contains('topIndex')) ||
+          (!this.leftIndex && item.classList.contains('leftIndex')) ||
+          (!this.bottomIndex && item.classList.contains('bottomIndex'))
+        ) {
+          if(item.classList.contains('leftIndex'))item.parentElement.remove();
+          item.remove();
+        }
+      });
+    });
+  }
+
+  updateStyles() {
+    const orientation = window.innerHeight > window.innerWidth ? 'portrait' : 'landscape';
+    this.style = {
+      height: parseProp(this.height, orientation),
+      width: parseProp(this.width, orientation),
+      zIndex: this.z,
+      display: parseProp(`${this.visible}`, orientation) === 'true' ? 'flex' : 'none',
+      borderRadius: parseProp(this.borderRadius, orientation),
+    };
+  }
+
+  handleClickSlot(element: HTMLElement) {
+    const index = parseInt(element.className.split(' ')[1].split('-')[1]);
+    const slotElements = document.querySelectorAll('.slot');
+    slotElements.forEach((el, i) => {
+      const slotEl = el as HTMLElement;
+      if (i < index) {
+        slotEl.classList.add('slot-active');
+        slotEl.classList.remove('slot-deactive');
+        if (this.matrixImage) {
+          slotEl.style.setProperty('--bg-image', `url(${convertUrlToRelative(this.matrixImage)})`);
+        }
+      } else {
+        slotEl.classList.remove('slot-active');
+        slotEl.classList.add('slot-deactive');
+      }
+    });
+  }
+
+  render() {
+    let slotNumber = 1;
+    return (
+      <Host class="math-matrix" style={{ height: this.style.height, width: this.style.width, z: this.style.z, display: this.style.display }}>
+        {Array.from({ length: this.rows + 1 }, (_, rowIndex) => (
+          <div class="slot-parent" key={`row-${rowIndex}`}>
+            <div style={rowIndex === 0 && { visibility: 'hidden' }} class="topIndex">
+              {rowIndex}
+            </div>
+            {Array.from({ length: this.cols }, (_, colIndex) =>
+              rowIndex === 0 ? (
+                <div class="leftIndex">{++colIndex}</div>
+              ) : (
+                <div
+                  class={`slot slot-${slotNumber++} ${this.defualtFill + 1 >= slotNumber ? 'slot-active' : 'slot-deactive'}`}
+                  onClick={() => this.handleClickSlot(event.target as HTMLElement)}
+                  key={`slot-${rowIndex}-${colIndex}`}
+                  style={{ borderRadius: this.style.borderRadius }}
+                ></div>
+              ),
+            )}
+            <div style={rowIndex === 0 && { visibility: 'hidden' }} class="bottomIndex">
+              {this.cols * rowIndex}
+            </div>
+          </div>
+        ))}
+      </Host>
+    );
+  }
+}

--- a/src/components/mathMatrix/readme.md
+++ b/src/components/mathMatrix/readme.md
@@ -16,9 +16,9 @@
 | `bottomIndex`       | `bottom-index`        | Show row index numbers on the bottom side                        | `boolean` | `false`             |
 | `clickable`         | `clickable`           | Enable/disable click interactions on the slots                   | `boolean` | `true`              |
 | `cols`              | `cols`                | Number of columns in the matrix                                  | `number`  | `5`                 |
-| `deactiveBgColor`   | `deactive-bg-color`   | Background color for inactive slots                              | `string`  | `'transparent'`     |
 | `defualtFill`       | `defualt-fill`        | Number of slots to pre-fill as active by default                 | `number`  | `0`                 |
 | `height`            | `height`              | Height of the slot container                                     | `string`  | `'100%'`            |
+| `inactiveBgColor`   | `inactive-bg-color`   | Background color for inactive slots                              | `string`  | `'transparent'`     |
 | `leftIndex`         | `left-index`          | Show row index numbers on the left side                          | `boolean` | `false`             |
 | `margin`            | `margin`              | Margin around the matrix container                               | `string`  | `undefined`         |
 | `matrixImage`       | `matrix-image`        | Image source used inside the slots                               | `string`  | `undefined`         |

--- a/src/components/mathMatrix/readme.md
+++ b/src/components/mathMatrix/readme.md
@@ -1,0 +1,48 @@
+# lido-math-matrix
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property            | Attribute             | Description                                                      | Type      | Default             |
+| ------------------- | --------------------- | ---------------------------------------------------------------- | --------- | ------------------- |
+| `activeBgColor`     | `active-bg-color`     | Background color for active slots                                | `string`  | `'red'`             |
+| `activeOnlyVisible` | `active-only-visible` | If true, only active slots are visible; inactive ones are hidden | `boolean` | `false`             |
+| `border`            | `border`              | Border style applied to each slot                                | `string`  | `'2px solid green'` |
+| `borderRadius`      | `border-radius`       | Border radius for each slot                                      | `string`  | `'5px'`             |
+| `bottomIndex`       | `bottom-index`        | Show row index numbers on the bottom side                        | `boolean` | `false`             |
+| `clickable`         | `clickable`           | Enable/disable click interactions on the slots                   | `boolean` | `true`              |
+| `cols`              | `cols`                | Number of columns in the matrix                                  | `number`  | `5`                 |
+| `deactiveBgColor`   | `deactive-bg-color`   | Background color for inactive slots                              | `string`  | `'transparent'`     |
+| `defualtFill`       | `defualt-fill`        | Number of slots to pre-fill as active by default                 | `number`  | `0`                 |
+| `height`            | `height`              | Height of the slot container                                     | `string`  | `'100%'`            |
+| `leftIndex`         | `left-index`          | Show row index numbers on the left side                          | `boolean` | `false`             |
+| `margin`            | `margin`              | Margin around the matrix container                               | `string`  | `undefined`         |
+| `matrixImage`       | `matrix-image`        | Image source used inside the slots                               | `string`  | `undefined`         |
+| `padding`           | `padding`             | Padding inside the matrix container                              | `string`  | `undefined`         |
+| `rows`              | `rows`                | Number of rows in the matrix                                     | `number`  | `7`                 |
+| `topIndex`          | `top-index`           | Show column index numbers on the top side                        | `boolean` | `false`             |
+| `visible`           | `visible`             | Controls visibility of the matrix (string "true" or "false")     | `string`  | `'false'`           |
+| `width`             | `width`               | Width of the slot container                                      | `string`  | `'100%'`            |
+| `z`                 | `z`                   | Z-index value for the matrix container                           | `string`  | `undefined`         |
+
+
+## Dependencies
+
+### Used by
+
+ - [lido-home](../home)
+
+### Graph
+```mermaid
+graph TD;
+  lido-home --> lido-math-matrix
+  style lido-math-matrix fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/root/readme.md
+++ b/src/components/root/readme.md
@@ -46,6 +46,7 @@ graph TD;
   lido-home --> lido-slide-fill
   lido-home --> lido-float
   lido-home --> lido-keyboard
+  lido-home --> lido-math-matrix
   lido-keyboard --> lido-text
   style lido-root fill:#f9f,stroke:#333,stroke-width:4px
 ```


### PR DESCRIPTION
<img width="871" height="563" alt="image" src="https://github.com/user-attachments/assets/7fd87906-2ec4-4e18-bafb-aae986a82913" />

- Clickable support for interactive boxes

- Customizable rows and columns

- Active/Inactive colors via active-bg-color and inactive-bg-color attributes

- Image support for active boxes using the matrix-image attribute

- Index labels with top-index, left-index, and bottom-index attributes

- Active-only visibility option

- Default fill support

- Border and border-radius customization

- Landscape and portrait modes (supported for width, height, border-radius, and z-index)

- Square boxes: all boxes remain square, scaled based on the component’s width and heightht