### PR TITLE
Fix bubbleType first click audio clash

### DIFF
--- a/src/utils/utilsHandlers/clickHandler.ts
+++ b/src/utils/utilsHandlers/clickHandler.ts
@@ -75,6 +75,18 @@ export function addClickListenerForClickType(element: HTMLElement): void {
   handlingElementFlexibleWidth(element, 'click');
   const container = document.getElementById(LidoContainer) as HTMLElement;
   if(container.getAttribute('canplay') === 'false')return;
+
+  const isBubbleTypeKeyboardKey =
+    container?.getAttribute('template-id') === 'bubbleType' &&
+    element.closest('lido-keyboard') !== null;
+
+  // BubbleType manages key clicks and audio in lido-keyboard.tsx directly.
+  // Letting the generic click handler attach here creates a competing stop/play
+  // path that can interrupt the first bubble audio.
+  if (isBubbleTypeKeyboardKey) {
+    return;
+  }
+
   element.style.cursor = 'pointer';
   if (!element) {
     console.error('No element provided.');


### PR DESCRIPTION
The bubble game had an issue where the first clicked letter’s audio was getting interrupted, so the sound did not play reliably on the first tap.

This happened because the bubble keyboard already had its own custom click and audio flow, but the shared generic click behavior was also getting applied to the same keys and creating a conflicting audio path.

We fixed it by making the bubble keyboard keys use only the bubble-specific interaction flow, so the first click audio is no longer paused immediately and playback works consistently.