### PR TITLE
fix: sync balance tilt with drop settle animation

### DIFF
--- a/src/components/scale/lido-balance.tsx
+++ b/src/components/scale/lido-balance.tsx
@@ -243,7 +243,7 @@ export class LidoBalance {
   async updateTilt(leftVal: number, rightVal: number) {
   const diff = rightVal - leftVal;
   const newTilt = Math.max(-5, Math.min(5, diff));
-  await new Promise(res => setTimeout(res, 350));
+  await new Promise(res => setTimeout(res, 700));
   this.tiltf = newTilt;   
   }
 


### PR DESCRIPTION
Updated the balance scale animation delay to 700ms, matching the dropped element’s settle duration so the element settles first and the scale responds afterward, creating a smoother and more natural animation flow.